### PR TITLE
Add nodelusion plugin to marketplace catalog

### DIFF
--- a/marketplace/.kodik-plugin/marketplace.json
+++ b/marketplace/.kodik-plugin/marketplace.json
@@ -322,6 +322,15 @@
     {
       "name": "teaching",
       "source": "./plugins/teaching"
+    },
+    {
+      "name": "nodelusion",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/alexeikrivilev-cyber/Nodelusion.git",
+        "path": "plugin-template",
+        "ref": "master"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the **Nodelusion** plugin to the official Kodik marketplace catalog.

Nodelusion is a Kodik-native design workflow plugin with runtime-backed design contract, preview bridge, deterministic visual QA, audit trail, export bundle, design diff, replay, debt ledger and safe refresh planning.

## Changes

- Adds `nodelusion` entry to `marketplace/.kodik-plugin/marketplace.json` using `git-subdir` source type
- Plugin source: `https://github.com/alexeikrivilev-cyber/Nodelusion.git` (subdir: `plugin-template`, ref: `master`)

## Plugin manifest

The plugin manifest at `plugin-template/.kodik-plugin/plugin.json` follows `schemaVersion: 1` with all required fields: `id`, `version`, `title`, `description`, `category`, `icon`, `author`, `homepageUrl`, `sourceUrl`, `tags`, `prompts`, `userConfig`.

## Verification

- Plugin manifest validated against schema
- Icon (`./assets/app-icon.svg`) is a repository-local vector SVG
- All plugin directories (skills, commands, rules, agents, hooks, mcp) present in source repo
- No import-only fields (`originalAuthor`, `sourceMarketplace`, `keywords`, `repository`, `license`) included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kodik-AI/codesmith/kodik/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786396154&installation_id=139152344&pr_number=15&repository=Kodik-AI%2Fkodik&return_to=https%3A%2F%2Fgithub.com%2FKodik-AI%2Fkodik%2Fpull%2F15&signature=c368ee1731efe59cabb318ee8a38b5cf45e45d2505df64da068c9fc21fd29fcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->